### PR TITLE
Potential fix for code scanning alert no. 1: Missing origin verification in `postMessage` handler

### DIFF
--- a/webview-ui/src/hooks/useVSCodeAPI.ts
+++ b/webview-ui/src/hooks/useVSCodeAPI.ts
@@ -29,7 +29,11 @@ export function useVSCodeAPI(): {
   const handlers = useRef(new Set<MessageHandler>());
 
   useEffect(() => {
+    const trustedOrigin = window.location.origin;
+    const trustedSource = window.parent;
+
     const receive = (event: MessageEvent<ExtensionMessage>) => {
+      if (event.origin !== trustedOrigin || event.source !== trustedSource) return;
       handlers.current.forEach((handler) => handler(event.data));
     };
     window.addEventListener('message', receive);


### PR DESCRIPTION
Potential fix for [https://github.com/mohsinsurani/quackwrangler/security/code-scanning/1](https://github.com/mohsinsurani/quackwrangler/security/code-scanning/1)

Add an origin (and source) trust check inside the `receive` message handler in `webview-ui/src/hooks/useVSCodeAPI.ts` before forwarding `event.data` to subscribers.

Best fix with minimal behavior change:
- In the `useEffect` block, compute trusted values once:
  - `const trustedOrigin = window.location.origin;`
  - `const trustedSource = window.parent;`
- In `receive`, early-return unless:
  - `event.origin === trustedOrigin`
  - `event.source === trustedSource`
- Only then dispatch `event.data` to registered handlers.

Why this approach:
- It satisfies CodeQL’s required origin verification.
- It keeps existing functionality for legitimate extension->webview messages.
- It adds no external dependencies and avoids broad architectural changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
